### PR TITLE
Support sign up in the login flow

### DIFF
--- a/test.tsx
+++ b/test.tsx
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import { render } from 'ink-testing-library';
 import assert from 'node:assert';
 import Check from './source/commands/pdp/check.js';
+import Login from './source/commands/login.js';
 
 const API_KEY = process.env.API_KEY;
 
@@ -27,5 +28,33 @@ test('check', t => {
 			res,
 			'Checking user="filip@permit.io" action=create resource=task at tenant=default\n⠋',
 		);
+	});
+});
+
+test('login', t => {
+	t.test('Should prompt to create a new workspace if none found', () => {
+		const { lastFrame } = render(
+			<Login
+				options={{
+					key: API_KEY,
+					workspace: '',
+				}}
+			/>,
+		);
+		const res = lastFrame();
+		assert.equal(res, 'No workspaces found. Please create a new workspace.\n');
+	});
+
+	t.test('Should prompt to create a new project if none found', () => {
+		const { lastFrame } = render(
+			<Login
+				options={{
+					key: API_KEY,
+					workspace: 'existingWorkspace',
+				}}
+			/>,
+		);
+		const res = lastFrame();
+		assert.equal(res, 'No projects found. Please create a new project.\n');
 	});
 });


### PR DESCRIPTION
Related to #17

Add support for user sign-up in the `permit login` flow.

* **Login Flow Enhancements**
  - Add logic in `source/commands/login.tsx` to handle new user sign-ups and account creation during the login process.
  - Prompt users without an account to create a new workspace and project if none are found.
  - Update the state management to include the new sign-up flow.
  - Add API calls to create new workspace and project.

* **End-to-End Tests**
  - Add e2e tests in `test.tsx` to cover the new sign-up flow.
  - Ensure proper functionality of the new sign-up flow.

