### PR TITLE
feat(CLI): Add 'permit pdp check-url' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Use this command to check if a user has permission to access a specific URL. The
 - `--method <string>` (Optional) - the HTTP method to check permissions for (default: `GET`)
 - `--tenant <string>` (Optional) - the tenant to check permissions for (default: `default`)
 - `--user-attributes <string>` (Optional) - additional user attributes to enrich the authorization check in the format `key1:value1,key2:value2`. Can be specified multiple times.
-- `--pdpurl <string>` (Optional) - the PDP URL to check authorization against (default: Cloud PDP)
+- `--pdp-url <string>` (Optional) - the PDP URL to check authorization against (default: Cloud PDP)
 - `--api-key <string>` (Optional) - the API key for the Permit env, project or Workspace
 
 #### Example
@@ -195,7 +195,7 @@ $ permit pdp check-url --user john@example.com --url https://api.example.com/ord
 $ permit pdp check-url --user john@example.com --url https://api.example.com/orders --user-attributes role:admin --user-attributes department:sales
 
 # Check against local PDP
-$ permit pdp check-url --user john@example.com --url https://api.example.com/orders --pdpurl http://localhost:7766
+$ permit pdp check-url --user john@example.com --url https://api.example.com/orders --pdp-url http://localhost:7766
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ permit pdp check --user user@permit.io --action list --resource transactions
   - `run` - print a docker command to run your Permit PDP
   - `check` - perform an authorization check against the PDP
   - `stats` - view statistics about your PDP's performance and usage
-  - `check-url` - check user permission access
+  - `check-url` - check if a user has permission to access a URL
 - `env` - a collection of commands to manage Permit policy environments
   - `copy` - copy a Permit environment with its policies to another environment
   - `create` - create a new environment in a project

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ permit pdp check --user user@permit.io --action list --resource transactions
   - `run` - print a docker command to run your Permit PDP
   - `check` - perform an authorization check against the PDP
   - `stats` - view statistics about your PDP's performance and usage
+  - `check-url` - check user permission access
 - `env` - a collection of commands to manage Permit policy environments
   - `copy` - copy a Permit environment with its policies to another environment
   - `create` - create a new environment in a project
@@ -163,6 +164,37 @@ Use this command to view statistics about your PDP's performance and usage. This
 
 ```bash
 $ permit pdp stats
+```
+
+### `pdp check-url`
+
+Use this command to check if a user has permission to access a specific URL. The command verifies URL-based permissions against the PDP using the Permit.io URL authorization API.
+
+#### Options
+
+- `--user <string>` - the user id to check permissions for (Required)
+- `--url <string>` - the URL to check permissions for (Required)
+- `--method <string>` (Optional) - the HTTP method to check permissions for (default: `GET`)
+- `--tenant <string>` (Optional) - the tenant to check permissions for (default: `default`)
+- `--user-attributes <string>` (Optional) - additional user attributes to enrich the authorization check in the format `key1:value1,key2:value2`. Can be specified multiple times.
+- `--pdpurl <string>` (Optional) - the PDP URL to check authorization against (default: Cloud PDP)
+- `--api-key <string>` (Optional) - the API key for the Permit env, project or Workspace
+
+#### Example
+
+```bash
+# Basic URL permission check
+$ permit pdp check-url --user john@example.com --url https://api.example.com/orders
+
+# Check with specific HTTP method and tenant
+$ permit pdp check-url --user john@example.com --url https://api.example.com/orders --method POST --tenant acme-corp
+
+# Check with user attributes
+$ permit pdp check-url --user john@example.com --url https://api.example.com/orders --user-attributes role:admin --user-attributes department:sales
+
+# Check against local PDP
+$ permit pdp check-url --user john@example.com --url https://api.example.com/orders --pdpurl http://localhost:7766
+
 ```
 
 ---

--- a/source/commands/pdp/check-url.tsx
+++ b/source/commands/pdp/check-url.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import zod from 'zod';
+import { option } from 'pastel';
+import { AuthProvider } from '../../components/AuthProvider.js';
+import PDPCheckUrlComponent from '../../components/pdp/PDPCheckUrlComponent.js';
+
+export const description = 'Check if a user has permission to access a URL';
+
+export const options = zod.object({
+  user: zod
+    .string()
+    .min(1, 'User identifier cannot be empty')
+    .describe(
+      option({
+        description: 'Unique Identity to check for (Required)',
+        alias: 'u',
+      }),
+    ),
+  url: zod
+    .string()
+    .min(1, 'URL cannot be empty')
+    .describe(
+      option({
+        description: 'URL to check permissions for (Required)',
+      }),
+    ),
+  method: zod
+    .string()
+    .optional()
+    .default('GET')
+    .describe(
+      option({
+        description: 'HTTP method (Optional, defaults to "GET")',
+        alias: 'm',
+      }),
+    ),
+  tenant: zod
+    .string()
+    .optional()
+    .default('default')
+    .describe(
+      option({
+        description: 'The tenant the resource belongs to (Optional, defaults to "default")',
+        alias: 't',
+      }),
+    ),
+  userAttributes: zod
+    .array(zod.string())
+    .optional()
+    .describe(
+      option({
+        description: 'User attributes in format key1:value1,key2:value2 (Optional, can be specified multiple times)',
+        alias: 'ua',
+      }),
+    ),
+  pdpurl: zod
+    .string()
+    .optional()
+    .describe(
+      option({
+        description: 'The URL of the PDP service. Default to the cloud PDP. (Optional)',
+      }),
+    ),
+  apiKey: zod
+    .string()
+    .optional()
+    .describe(
+      option({
+        description: 'The API key for the Permit env, project or Workspace (Optional)',
+        alias: 'k',
+      }),
+    ),
+});
+
+export type PDPCheckUrlProps = {
+  options: zod.infer<typeof options>;
+};
+
+export default function CheckUrl({ options }: PDPCheckUrlProps) {
+  return (
+    <AuthProvider scope={'environment'} permit_key={options.apiKey}>
+      <PDPCheckUrlComponent options={options} />
+    </AuthProvider>
+  );
+}

--- a/source/commands/pdp/check-url.tsx
+++ b/source/commands/pdp/check-url.tsx
@@ -7,79 +7,83 @@ import PDPCheckUrlComponent from '../../components/pdp/PDPCheckUrlComponent.js';
 export const description = 'Check if a user has permission to access a URL';
 
 export const options = zod.object({
-  user: zod
-    .string()
-    .min(1, 'User identifier cannot be empty')
-    .describe(
-      option({
-        description: 'Unique Identity to check for (Required)',
-        alias: 'u',
-      }),
-    ),
-  url: zod
-    .string()
-    .min(1, 'URL cannot be empty')
-    .describe(
-      option({
-        description: 'URL to check permissions for (Required)',
-      }),
-    ),
-  method: zod
-    .string()
-    .optional()
-    .default('GET')
-    .describe(
-      option({
-        description: 'HTTP method (Optional, defaults to "GET")',
-        alias: 'm',
-      }),
-    ),
-  tenant: zod
-    .string()
-    .optional()
-    .default('default')
-    .describe(
-      option({
-        description: 'The tenant the resource belongs to (Optional, defaults to "default")',
-        alias: 't',
-      }),
-    ),
-  userAttributes: zod
-    .array(zod.string())
-    .optional()
-    .describe(
-      option({
-        description: 'User attributes in format key1:value1,key2:value2 (Optional, can be specified multiple times)',
-        alias: 'ua',
-      }),
-    ),
-  pdpurl: zod
-    .string()
-    .optional()
-    .describe(
-      option({
-        description: 'The URL of the PDP service. Default to the cloud PDP. (Optional)',
-      }),
-    ),
-  apiKey: zod
-    .string()
-    .optional()
-    .describe(
-      option({
-        description: 'The API key for the Permit env, project or Workspace (Optional)',
-        alias: 'k',
-      }),
-    ),
+	user: zod
+		.string()
+		.min(1, 'User identifier cannot be empty')
+		.describe(
+			option({
+				description: 'Unique Identity to check for (Required)',
+				alias: 'u',
+			}),
+		),
+	url: zod
+		.string()
+		.min(1, 'URL cannot be empty')
+		.describe(
+			option({
+				description: 'URL to check permissions for (Required)',
+			}),
+		),
+	method: zod
+		.string()
+		.optional()
+		.default('GET')
+		.describe(
+			option({
+				description: 'HTTP method (Optional, defaults to "GET")',
+				alias: 'm',
+			}),
+		),
+	tenant: zod
+		.string()
+		.optional()
+		.default('default')
+		.describe(
+			option({
+				description:
+					'The tenant the resource belongs to (Optional, defaults to "default")',
+				alias: 't',
+			}),
+		),
+	userAttributes: zod
+		.array(zod.string())
+		.optional()
+		.describe(
+			option({
+				description:
+					'User attributes in format key1:value1,key2:value2 (Optional, can be specified multiple times)',
+				alias: 'ua',
+			}),
+		),
+	pdpurl: zod
+		.string()
+		.optional()
+		.describe(
+			option({
+				description:
+					'The URL of the PDP service. Default to the cloud PDP. (Optional)',
+			}),
+		),
+	apiKey: zod
+		.string()
+		.optional()
+		.describe(
+			option({
+				description:
+					'The API key for the Permit env, project or Workspace (Optional)',
+				alias: 'k',
+			}),
+		),
 });
 
 export type PDPCheckUrlProps = {
-  options: zod.infer<typeof options>;
+	options: zod.infer<typeof options>;
 };
 
 export default function CheckUrl({ options }: PDPCheckUrlProps) {
-  return (
-    <AuthProvider scope={'environment'} permit_key={options.apiKey}>
-      <PDPCheckUrlComponent options={options} />
-    </AuthProvider>
-  );
+	return (
+		<AuthProvider scope={'environment'} permit_key={options.apiKey}>
+			<PDPCheckUrlComponent options={options} />
+		</AuthProvider>
+	);
 }

--- a/source/commands/pdp/check-url.tsx
+++ b/source/commands/pdp/check-url.tsx
@@ -55,13 +55,14 @@ export const options = zod.object({
 				alias: 'ua',
 			}),
 		),
-	pdpurl: zod
+	'pdp-url': zod
 		.string()
 		.optional()
+		.default('http://localhost:7766')
 		.describe(
 			option({
 				description:
-					'The URL of the PDP service. Default to the cloud PDP. (Optional)',
+					'The URL of the PDP service. Defaults to http://localhost:7766. (Optional)',
 			}),
 		),
 	apiKey: zod

--- a/source/components/pdp/PDPCheckUrlComponent.tsx
+++ b/source/components/pdp/PDPCheckUrlComponent.tsx
@@ -7,100 +7,103 @@ import { PDPCheckUrlProps } from '../../commands/pdp/check-url.js';
 
 // Interface for the component's state
 interface CheckUrlState {
-  loading: boolean;
-  result: boolean | null;
-  error: string | null;
+	loading: boolean;
+	result: boolean | null;
+	error: string | null;
 }
 
 const PDPCheckUrlComponent: React.FC<PDPCheckUrlProps> = ({ options }) => {
-  const [state, setState] = useState<CheckUrlState>({
-    loading: true,
-    result: null,
-    error: null,
-  });
+	const [state, setState] = useState<CheckUrlState>({
+		loading: true,
+		result: null,
+		error: null,
+	});
 
-  const { getAllowedUrlCheck } = useCheckPdpApi();
+	const { getAllowedUrlCheck } = useCheckPdpApi();
 
-  useEffect(() => {
-    const checkUrl = async () => {
-      try {
-        // Parse user attributes if provided
-        const userAttributesObj: Record<string, string | number | boolean> = {};
-        
-        if (options.userAttributes && options.userAttributes.length > 0) {
-          for (const attrPair of options.userAttributes) {
-            const parsedAttrs = parseAttributes(attrPair);
-            Object.assign(userAttributesObj, parsedAttrs);
-          }
-        }
+	useEffect(() => {
+		const checkUrl = async () => {
+			try {
+				// Parse user attributes if provided
+				const userAttributesObj: Record<string, string | number | boolean> = {};
 
-        // Prepare the request payload
-        const payload = {
-          user: {
-            key: options.user,
-            // Always include attributes as a required field
-            attributes: userAttributesObj,
-          },
-          url: options.url,
-          http_method: options.method,
-          tenant: options.tenant,
-          context: {}, // Required empty object
-          sdk: 'permit-cli'
-        };
+				if (options.userAttributes && options.userAttributes.length > 0) {
+					for (const attrPair of options.userAttributes) {
+						const parsedAttrs = parseAttributes(attrPair);
+						Object.assign(userAttributesObj, parsedAttrs);
+					}
+				}
 
-        // Make the API call
-        const { data, error } = await getAllowedUrlCheck(payload, options.pdpurl);
+				// Prepare the request payload
+				const payload = {
+					user: {
+						key: options.user,
+						// Always include attributes as a required field
+						attributes: userAttributesObj,
+					},
+					url: options.url,
+					http_method: options.method,
+					tenant: options.tenant,
+					context: {}, // Required empty object
+					sdk: 'permit-cli',
+				};
 
-        if (error) {
-          setState({ loading: false, result: null, error });
-          return;
-        }
+				// Make the API call
+				const { data, error } = await getAllowedUrlCheck(
+					payload,
+					options.pdpurl,
+				);
 
-        setState({ loading: false, result: data?.allow ?? false, error: null });
-      } catch (e) {
-        setState({
-          loading: false,
-          result: null,
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
-    };
+				if (error) {
+					setState({ loading: false, result: null, error });
+					return;
+				}
 
-    checkUrl();
-  }, [options, getAllowedUrlCheck]);
+				setState({ loading: false, result: data?.allow ?? false, error: null });
+			} catch (e) {
+				setState({
+					loading: false,
+					result: null,
+					error: e instanceof Error ? e.message : String(e),
+				});
+			}
+		};
 
-  if (state.loading) {
-    return (
-      <Text>
-        <Spinner type="dots" /> Checking URL permission...
-      </Text>
-    );
-  }
+		checkUrl();
+	}, [options, getAllowedUrlCheck]);
 
-  if (state.error) {
-    return (
-      <Box flexDirection="column">
-        <Text color="red">Error checking URL permission:</Text>
-        <Text>{state.error}</Text>
-      </Box>
-    );
-  }
+	if (state.loading) {
+		return (
+			<Text>
+				<Spinner type="dots" /> Checking URL permission...
+			</Text>
+		);
+	}
 
-  return (
-    <Box flexDirection="column">
-      <Text>URL: {options.url}</Text>
-      <Text>Method: {options.method}</Text>
-      <Text>User: {options.user}</Text>
-      <Text>Tenant: {options.tenant}</Text>
-      <Text>
-        {state.result === true ? (
-          <Text color="green">✓ Allowed</Text>
-        ) : (
-          <Text color="red">✗ Denied</Text>
-        )}
-      </Text>
-    </Box>
-  );
+	if (state.error) {
+		return (
+			<Box flexDirection="column">
+				<Text color="red">Error checking URL permission:</Text>
+				<Text>{state.error}</Text>
+			</Box>
+		);
+	}
+
+	return (
+		<Box flexDirection="column">
+			<Text>URL: {options.url}</Text>
+			<Text>Method: {options.method}</Text>
+			<Text>User: {options.user}</Text>
+			<Text>Tenant: {options.tenant}</Text>
+			<Text>
+				{state.result === true ? (
+					<Text color="green">✓ Allowed</Text>
+				) : (
+					<Text color="red">✗ Denied</Text>
+				)}
+			</Text>
+		</Box>
+	);
 };
 
 export default PDPCheckUrlComponent;

--- a/source/components/pdp/PDPCheckUrlComponent.tsx
+++ b/source/components/pdp/PDPCheckUrlComponent.tsx
@@ -26,7 +26,6 @@ const PDPCheckUrlComponent: React.FC<PDPCheckUrlProps> = ({ options }) => {
 			try {
 				// Parse user attributes if provided
 				const userAttributesObj: Record<string, string | number | boolean> = {};
-
 				if (options.userAttributes && options.userAttributes.length > 0) {
 					for (const attrPair of options.userAttributes) {
 						const parsedAttrs = parseAttributes(attrPair);
@@ -51,7 +50,7 @@ const PDPCheckUrlComponent: React.FC<PDPCheckUrlProps> = ({ options }) => {
 				// Make the API call
 				const { data, error } = await getAllowedUrlCheck(
 					payload,
-					options.pdpurl,
+					options['pdp-url'],
 				);
 
 				if (error) {

--- a/source/components/pdp/PDPCheckUrlComponent.tsx
+++ b/source/components/pdp/PDPCheckUrlComponent.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { Text, Box } from 'ink';
+import Spinner from 'ink-spinner';
+import { parseAttributes } from '../../utils/attributes.js';
+import { useCheckPdpApi } from '../../hooks/useCheckPdpApi.js';
+import { PDPCheckUrlProps } from '../../commands/pdp/check-url.js';
+
+// Interface for the component's state
+interface CheckUrlState {
+  loading: boolean;
+  result: boolean | null;
+  error: string | null;
+}
+
+const PDPCheckUrlComponent: React.FC<PDPCheckUrlProps> = ({ options }) => {
+  const [state, setState] = useState<CheckUrlState>({
+    loading: true,
+    result: null,
+    error: null,
+  });
+
+  const { getAllowedUrlCheck } = useCheckPdpApi();
+
+  useEffect(() => {
+    const checkUrl = async () => {
+      try {
+        // Parse user attributes if provided
+        const userAttributesObj: Record<string, string | number | boolean> = {};
+        
+        if (options.userAttributes && options.userAttributes.length > 0) {
+          for (const attrPair of options.userAttributes) {
+            const parsedAttrs = parseAttributes(attrPair);
+            Object.assign(userAttributesObj, parsedAttrs);
+          }
+        }
+
+        // Prepare the request payload
+        const payload = {
+          user: {
+            key: options.user,
+            // Always include attributes as a required field
+            attributes: userAttributesObj,
+          },
+          url: options.url,
+          http_method: options.method,
+          tenant: options.tenant,
+          context: {}, // Required empty object
+          sdk: 'permit-cli'
+        };
+
+        // Make the API call
+        const { data, error } = await getAllowedUrlCheck(payload, options.pdpurl);
+
+        if (error) {
+          setState({ loading: false, result: null, error });
+          return;
+        }
+
+        setState({ loading: false, result: data?.allow ?? false, error: null });
+      } catch (e) {
+        setState({
+          loading: false,
+          result: null,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    };
+
+    checkUrl();
+  }, [options, getAllowedUrlCheck]);
+
+  if (state.loading) {
+    return (
+      <Text>
+        <Spinner type="dots" /> Checking URL permission...
+      </Text>
+    );
+  }
+
+  if (state.error) {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">Error checking URL permission:</Text>
+        <Text>{state.error}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text>URL: {options.url}</Text>
+      <Text>Method: {options.method}</Text>
+      <Text>User: {options.user}</Text>
+      <Text>Tenant: {options.tenant}</Text>
+      <Text>
+        {state.result === true ? (
+          <Text color="green">✓ Allowed</Text>
+        ) : (
+          <Text color="red">✗ Denied</Text>
+        )}
+      </Text>
+    </Box>
+  );
+};
+
+export default PDPCheckUrlComponent;

--- a/source/hooks/useCheckPdpApi.ts
+++ b/source/hooks/useCheckPdpApi.ts
@@ -4,6 +4,21 @@ import useClient from './useClient.js';
 
 export type AuthorizationQuery = components['schemas']['AuthorizationQuery'];
 
+export interface UrlRequestInput {
+	user: {
+		key: string;
+		firstName?: string;
+		lastName?: string;
+		email?: string;
+		attributes: Record<string, string | number | boolean>;
+	};
+	http_method: string;
+	url: string;
+	tenant: string;
+	context: Record<string, unknown>;
+	sdk?: string;
+}
+
 export const useCheckPdpApi = () => {
 	const { authenticatedPdpClient } = useClient();
 
@@ -18,13 +33,29 @@ export const useCheckPdpApi = () => {
 		[authenticatedPdpClient],
 	);
 
-	// Method for URL permission check using type assertion for compatibility
 	const getAllowedUrlCheck = useCallback(
-		async (body: any, pdp_url?: string) => {
+		async (requestInput: UrlRequestInput, pdp_url?: string) => {
+			const apiBody = { ...requestInput };
+
+			type ApiCompliantBody = {
+				user: {
+					key: string;
+					firstName?: string;
+					lastName?: string;
+					email?: string;
+					attributes: Record<string, never>;
+				};
+				http_method: string;
+				url: string;
+				tenant: string;
+				context: Record<string, never>;
+				sdk?: string;
+			};
+
 			return await authenticatedPdpClient(pdp_url).POST(
 				'/allowed_url',
 				undefined,
-				body,
+				apiBody as unknown as ApiCompliantBody,
 			);
 		},
 		[authenticatedPdpClient],

--- a/source/hooks/useCheckPdpApi.ts
+++ b/source/hooks/useCheckPdpApi.ts
@@ -5,23 +5,36 @@ import useClient from './useClient.js';
 export type AuthorizationQuery = components['schemas']['AuthorizationQuery'];
 
 export const useCheckPdpApi = () => {
-	const { authenticatedPdpClient } = useClient();
+  const { authenticatedPdpClient } = useClient();
 
-	const getAllowedCheck = useCallback(
-		async (body: AuthorizationQuery, pdp_url?: string) => {
-			return await authenticatedPdpClient(pdp_url).POST(
-				'/allowed',
-				undefined,
-				body,
-			);
-		},
-		[authenticatedPdpClient],
-	);
+  const getAllowedCheck = useCallback(
+    async (body: AuthorizationQuery, pdp_url?: string) => {
+      return await authenticatedPdpClient(pdp_url).POST(
+        '/allowed',
+        undefined,
+        body,
+      );
+    },
+    [authenticatedPdpClient],
+  );
 
-	return useMemo(
-		() => ({
-			getAllowedCheck,
-		}),
-		[getAllowedCheck],
-	);
+  // Method for URL permission check using type assertion for compatibility
+  const getAllowedUrlCheck = useCallback(
+    async (body: any, pdp_url?: string) => {
+      return await authenticatedPdpClient(pdp_url).POST(
+        '/allowed_url',
+        undefined,
+        body, 
+      );
+    },
+    [authenticatedPdpClient],
+  );
+
+  return useMemo(
+    () => ({
+      getAllowedCheck,
+      getAllowedUrlCheck,
+    }),
+    [getAllowedCheck, getAllowedUrlCheck],
+  );
 };

--- a/source/hooks/useCheckPdpApi.ts
+++ b/source/hooks/useCheckPdpApi.ts
@@ -5,36 +5,36 @@ import useClient from './useClient.js';
 export type AuthorizationQuery = components['schemas']['AuthorizationQuery'];
 
 export const useCheckPdpApi = () => {
-  const { authenticatedPdpClient } = useClient();
+	const { authenticatedPdpClient } = useClient();
 
-  const getAllowedCheck = useCallback(
-    async (body: AuthorizationQuery, pdp_url?: string) => {
-      return await authenticatedPdpClient(pdp_url).POST(
-        '/allowed',
-        undefined,
-        body,
-      );
-    },
-    [authenticatedPdpClient],
-  );
+	const getAllowedCheck = useCallback(
+		async (body: AuthorizationQuery, pdp_url?: string) => {
+			return await authenticatedPdpClient(pdp_url).POST(
+				'/allowed',
+				undefined,
+				body,
+			);
+		},
+		[authenticatedPdpClient],
+	);
 
-  // Method for URL permission check using type assertion for compatibility
-  const getAllowedUrlCheck = useCallback(
-    async (body: any, pdp_url?: string) => {
-      return await authenticatedPdpClient(pdp_url).POST(
-        '/allowed_url',
-        undefined,
-        body, 
-      );
-    },
-    [authenticatedPdpClient],
-  );
+	// Method for URL permission check using type assertion for compatibility
+	const getAllowedUrlCheck = useCallback(
+		async (body: any, pdp_url?: string) => {
+			return await authenticatedPdpClient(pdp_url).POST(
+				'/allowed_url',
+				undefined,
+				body,
+			);
+		},
+		[authenticatedPdpClient],
+	);
 
-  return useMemo(
-    () => ({
-      getAllowedCheck,
-      getAllowedUrlCheck,
-    }),
-    [getAllowedCheck, getAllowedUrlCheck],
-  );
+	return useMemo(
+		() => ({
+			getAllowedCheck,
+			getAllowedUrlCheck,
+		}),
+		[getAllowedCheck, getAllowedUrlCheck],
+	);
 };

--- a/tests/PDPCheckUrl.test.tsx
+++ b/tests/PDPCheckUrl.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import CheckUrl, { options } from '../source/commands/pdp/check-url.js';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Mock the AuthProvider component
+vi.mock('../source/components/AuthProvider.js', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock the PDPCheckUrlComponent
+vi.mock('../source/components/pdp/PDPCheckUrlComponent.js', () => ({
+  __esModule: true,
+  default: vi.fn(() => <div>PDPCheckUrlComponent</div>),
+}));
+
+describe('CheckUrl Command', () => {
+  const defaultOptions = {
+    user: 'john@example.com',
+    url: 'https://example.com/endpoint',
+    method: 'GET',
+    tenant: 'default',
+    userAttributes: [],
+    pdpurl: undefined,
+    apiKey: undefined,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the PDPCheckUrlComponent with the correct props', () => {
+    const { lastFrame } = render(
+      <CheckUrl options={defaultOptions} />
+    );
+    expect(lastFrame()).toBeDefined();
+  });
+
+  it('validates required options', () => {
+    // Verify that user is required
+    const result1 = options.safeParse({
+      url: 'https://example.com/endpoint',
+    });
+    expect(result1.success).toBe(false);
+
+    // Verify that url is required
+    const result2 = options.safeParse({
+      user: 'john@example.com',
+    });
+    expect(result2.success).toBe(false);
+
+    // Both user and url are provided, should succeed
+    const result3 = options.safeParse({
+      user: 'john@example.com',
+      url: 'https://example.com/endpoint',
+    });
+    expect(result3.success).toBe(true);
+  });
+
+  it('accepts optional parameters', () => {
+    const result = options.safeParse({
+      user: 'john@example.com',
+      url: 'https://example.com/endpoint',
+      method: 'POST',
+      tenant: 'custom-tenant',
+      userAttributes: ['role:admin', 'department:engineering'],
+      pdpurl: 'http://localhost:7766',
+      apiKey: 'permit_key_12345', 
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.method).toBe('POST');
+      expect(result.data.tenant).toBe('custom-tenant');
+      expect(result.data.userAttributes).toEqual(['role:admin', 'department:engineering']);
+      expect(result.data.pdpurl).toBe('http://localhost:7766');
+      expect(result.data.apiKey).toBe('permit_key_12345'); 
+    }
+  });
+
+  it('provides default values for optional parameters', () => {
+    const result = options.safeParse({
+      user: 'john@example.com',
+      url: 'https://example.com/endpoint',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.method).toBe('GET');
+      expect(result.data.tenant).toBe('default');
+    }
+  });
+});

--- a/tests/PDPCheckUrl.test.tsx
+++ b/tests/PDPCheckUrl.test.tsx
@@ -23,7 +23,7 @@ describe('CheckUrl Command', () => {
 		method: 'GET',
 		tenant: 'default',
 		userAttributes: [],
-		pdpurl: undefined,
+		'pdp-url': undefined,
 		apiKey: undefined,
 	};
 
@@ -64,7 +64,7 @@ describe('CheckUrl Command', () => {
 			method: 'POST',
 			tenant: 'custom-tenant',
 			userAttributes: ['role:admin', 'department:engineering'],
-			pdpurl: 'http://localhost:7766',
+			'pdp-url': 'http://localhost:7766',
 			apiKey: 'permit_key_12345',
 		});
 
@@ -76,7 +76,7 @@ describe('CheckUrl Command', () => {
 				'role:admin',
 				'department:engineering',
 			]);
-			expect(result.data.pdpurl).toBe('http://localhost:7766');
+			expect(result.data['pdp-url']).toBe('http://localhost:7766');
 			expect(result.data.apiKey).toBe('permit_key_12345');
 		}
 	});
@@ -86,10 +86,12 @@ describe('CheckUrl Command', () => {
 			user: 'john@example.com',
 			url: 'https://example.com/endpoint',
 		});
+
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data.method).toBe('GET');
 			expect(result.data.tenant).toBe('default');
+			expect(result.data['pdp-url']).toBe('http://localhost:7766');
 		}
 	});
 });

--- a/tests/PDPCheckUrl.test.tsx
+++ b/tests/PDPCheckUrl.test.tsx
@@ -5,88 +5,91 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 // Mock the AuthProvider component
 vi.mock('../source/components/AuthProvider.js', () => ({
-  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	AuthProvider: ({ children }: { children: React.ReactNode }) => (
+		<>{children}</>
+	),
 }));
 
 // Mock the PDPCheckUrlComponent
 vi.mock('../source/components/pdp/PDPCheckUrlComponent.js', () => ({
-  __esModule: true,
-  default: vi.fn(() => <div>PDPCheckUrlComponent</div>),
+	__esModule: true,
+	default: vi.fn(() => <div>PDPCheckUrlComponent</div>),
 }));
 
 describe('CheckUrl Command', () => {
-  const defaultOptions = {
-    user: 'john@example.com',
-    url: 'https://example.com/endpoint',
-    method: 'GET',
-    tenant: 'default',
-    userAttributes: [],
-    pdpurl: undefined,
-    apiKey: undefined,
-  };
+	const defaultOptions = {
+		user: 'john@example.com',
+		url: 'https://example.com/endpoint',
+		method: 'GET',
+		tenant: 'default',
+		userAttributes: [],
+		pdpurl: undefined,
+		apiKey: undefined,
+	};
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-  it('renders the PDPCheckUrlComponent with the correct props', () => {
-    const { lastFrame } = render(
-      <CheckUrl options={defaultOptions} />
-    );
-    expect(lastFrame()).toBeDefined();
-  });
+	it('renders the PDPCheckUrlComponent with the correct props', () => {
+		const { lastFrame } = render(<CheckUrl options={defaultOptions} />);
+		expect(lastFrame()).toBeDefined();
+	});
 
-  it('validates required options', () => {
-    // Verify that user is required
-    const result1 = options.safeParse({
-      url: 'https://example.com/endpoint',
-    });
-    expect(result1.success).toBe(false);
+	it('validates required options', () => {
+		// Verify that user is required
+		const result1 = options.safeParse({
+			url: 'https://example.com/endpoint',
+		});
+		expect(result1.success).toBe(false);
 
-    // Verify that url is required
-    const result2 = options.safeParse({
-      user: 'john@example.com',
-    });
-    expect(result2.success).toBe(false);
+		// Verify that url is required
+		const result2 = options.safeParse({
+			user: 'john@example.com',
+		});
+		expect(result2.success).toBe(false);
 
-    // Both user and url are provided, should succeed
-    const result3 = options.safeParse({
-      user: 'john@example.com',
-      url: 'https://example.com/endpoint',
-    });
-    expect(result3.success).toBe(true);
-  });
+		// Both user and url are provided, should succeed
+		const result3 = options.safeParse({
+			user: 'john@example.com',
+			url: 'https://example.com/endpoint',
+		});
+		expect(result3.success).toBe(true);
+	});
 
-  it('accepts optional parameters', () => {
-    const result = options.safeParse({
-      user: 'john@example.com',
-      url: 'https://example.com/endpoint',
-      method: 'POST',
-      tenant: 'custom-tenant',
-      userAttributes: ['role:admin', 'department:engineering'],
-      pdpurl: 'http://localhost:7766',
-      apiKey: 'permit_key_12345', 
-    });
+	it('accepts optional parameters', () => {
+		const result = options.safeParse({
+			user: 'john@example.com',
+			url: 'https://example.com/endpoint',
+			method: 'POST',
+			tenant: 'custom-tenant',
+			userAttributes: ['role:admin', 'department:engineering'],
+			pdpurl: 'http://localhost:7766',
+			apiKey: 'permit_key_12345',
+		});
 
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.method).toBe('POST');
-      expect(result.data.tenant).toBe('custom-tenant');
-      expect(result.data.userAttributes).toEqual(['role:admin', 'department:engineering']);
-      expect(result.data.pdpurl).toBe('http://localhost:7766');
-      expect(result.data.apiKey).toBe('permit_key_12345'); 
-    }
-  });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.method).toBe('POST');
+			expect(result.data.tenant).toBe('custom-tenant');
+			expect(result.data.userAttributes).toEqual([
+				'role:admin',
+				'department:engineering',
+			]);
+			expect(result.data.pdpurl).toBe('http://localhost:7766');
+			expect(result.data.apiKey).toBe('permit_key_12345');
+		}
+	});
 
-  it('provides default values for optional parameters', () => {
-    const result = options.safeParse({
-      user: 'john@example.com',
-      url: 'https://example.com/endpoint',
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.method).toBe('GET');
-      expect(result.data.tenant).toBe('default');
-    }
-  });
+	it('provides default values for optional parameters', () => {
+		const result = options.safeParse({
+			user: 'john@example.com',
+			url: 'https://example.com/endpoint',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.method).toBe('GET');
+			expect(result.data.tenant).toBe('default');
+		}
+	});
 });

--- a/tests/components/PDPCheckUrlComponent.test.tsx
+++ b/tests/components/PDPCheckUrlComponent.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import PDPCheckUrlComponent from '../../source/components/pdp/PDPCheckUrlComponent.js';
+
+// Create a mock function outside the mock definition
+const getAllowedUrlCheckMock = vi.fn();
+
+// Mock the hooks and utilities
+vi.mock('../../source/hooks/useCheckPdpApi.js', () => ({
+  useCheckPdpApi: () => ({
+    getAllowedUrlCheck: getAllowedUrlCheckMock
+  })
+}));
+
+vi.mock('../../source/utils/attributes.js', () => ({
+  parseAttributes: (attr) => {
+    // Simple attribute parser mock
+    if (attr === 'role:admin') return { role: 'admin' };
+    if (attr === 'department:sales') return { department: 'sales' };
+    return {};
+  },
+}));
+
+describe('PDPCheckUrlComponent', () => {
+  beforeEach(() => {
+    // Reset mock before each test
+    getAllowedUrlCheckMock.mockReset();
+  });
+
+  it('renders loading state initially', () => {
+    // Setup mock to not resolve immediately
+    getAllowedUrlCheckMock.mockReturnValue(new Promise(() => {}));
+    
+    const { lastFrame } = render(
+      <PDPCheckUrlComponent 
+        options={{
+          user: 'john@example.com',
+          url: 'https://example.com/api',
+          method: 'GET',
+          tenant: 'default',
+        }} 
+      />
+    );
+    
+    expect(lastFrame()).toContain('Checking URL permission');
+  });
+
+  it('displays allowed result when permission is granted', async () => {
+    // Mock successful permission check
+    getAllowedUrlCheckMock.mockResolvedValue({ 
+      data: { allow: true },
+      error: null 
+    });
+    
+    const { lastFrame } = render(
+      <PDPCheckUrlComponent 
+        options={{
+          user: 'john@example.com',
+          url: 'https://example.com/api',
+          method: 'GET',
+          tenant: 'default',
+        }} 
+      />
+    );
+    
+    // Wait for the component to update
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('Allowed');
+    });
+    
+    expect(lastFrame()).toContain('✓ Allowed');
+    expect(lastFrame()).toContain('URL: https://example.com/api');
+    expect(lastFrame()).toContain('User: john@example.com');
+  });
+
+  it('displays denied result when permission is not granted', async () => {
+    // Mock denied permission check
+    getAllowedUrlCheckMock.mockResolvedValue({ 
+      data: { allow: false },
+      error: null 
+    });
+    
+    const { lastFrame } = render(
+      <PDPCheckUrlComponent 
+        options={{
+          user: 'john@example.com',
+          url: 'https://example.com/private',
+          method: 'POST',
+          tenant: 'acme-corp',
+        }} 
+      />
+    );
+    
+    // Wait for the component to update
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('Denied');
+    });
+    
+    expect(lastFrame()).toContain('✗ Denied');
+    expect(lastFrame()).toContain('URL: https://example.com/private');
+    expect(lastFrame()).toContain('Tenant: acme-corp');
+  });
+
+  it('handles user attributes correctly', async () => {
+    // Mock successful permission check
+    getAllowedUrlCheckMock.mockResolvedValue({ 
+      data: { allow: true },
+      error: null 
+    });
+    
+    render(
+      <PDPCheckUrlComponent 
+        options={{
+          user: 'john@example.com',
+          url: 'https://example.com/api',
+          method: 'GET',
+          tenant: 'default',
+          userAttributes: ['role:admin', 'department:sales'],
+        }} 
+      />
+    );
+    
+    // Wait for the component to process
+    await vi.waitFor(() => {
+      expect(getAllowedUrlCheckMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: expect.objectContaining({
+            key: 'john@example.com',
+            attributes: expect.objectContaining({
+              role: 'admin',
+              department: 'sales',
+            }),
+          }),
+        }),
+        undefined
+      );
+    });
+  });
+
+  it('displays error message when API call fails', async () => {
+    // Mock API error
+    getAllowedUrlCheckMock.mockResolvedValue({ 
+      data: null,
+      error: 'Failed to connect to PDP' 
+    });
+    
+    const { lastFrame } = render(
+      <PDPCheckUrlComponent 
+        options={{
+          user: 'john@example.com',
+          url: 'https://example.com/api',
+          method: 'GET',
+          tenant: 'default',
+        }} 
+      />
+    );
+    
+    // Wait for the component to update
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('Error');
+    });
+    
+    expect(lastFrame()).toContain('Error checking URL permission');
+    expect(lastFrame()).toContain('Failed to connect to PDP');
+  });
+
+  it('uses custom PDP URL when provided', async () => {
+    // Mock successful permission check
+    getAllowedUrlCheckMock.mockResolvedValue({ 
+      data: { allow: true },
+      error: null 
+    });
+    
+    const customPdpUrl = 'http://localhost:7766';
+    
+    render(
+      <PDPCheckUrlComponent 
+        options={{
+          user: 'john@example.com',
+          url: 'https://example.com/api',
+          method: 'GET',
+          tenant: 'default',
+          pdpurl: customPdpUrl,
+        }} 
+      />
+    );
+    
+    // Verify the custom PDP URL was passed to the hook
+    await vi.waitFor(() => {
+      expect(getAllowedUrlCheckMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        customPdpUrl
+      );
+    });
+  });
+});

--- a/tests/components/PDPCheckUrlComponent.test.tsx
+++ b/tests/components/PDPCheckUrlComponent.test.tsx
@@ -181,7 +181,7 @@ describe('PDPCheckUrlComponent', () => {
 					url: 'https://example.com/api',
 					method: 'GET',
 					tenant: 'default',
-					pdpurl: customPdpUrl,
+					'pdp-url': customPdpUrl,
 				}}
 			/>,
 		);

--- a/tests/components/PDPCheckUrlComponent.test.tsx
+++ b/tests/components/PDPCheckUrlComponent.test.tsx
@@ -8,190 +8,190 @@ const getAllowedUrlCheckMock = vi.fn();
 
 // Mock the hooks and utilities
 vi.mock('../../source/hooks/useCheckPdpApi.js', () => ({
-  useCheckPdpApi: () => ({
-    getAllowedUrlCheck: getAllowedUrlCheckMock
-  })
+	useCheckPdpApi: () => ({
+		getAllowedUrlCheck: getAllowedUrlCheckMock,
+	}),
 }));
 
 vi.mock('../../source/utils/attributes.js', () => ({
-  parseAttributes: (attr) => {
-    // Simple attribute parser mock
-    if (attr === 'role:admin') return { role: 'admin' };
-    if (attr === 'department:sales') return { department: 'sales' };
-    return {};
-  },
+	parseAttributes: attr => {
+		// Simple attribute parser mock
+		if (attr === 'role:admin') return { role: 'admin' };
+		if (attr === 'department:sales') return { department: 'sales' };
+		return {};
+	},
 }));
 
 describe('PDPCheckUrlComponent', () => {
-  beforeEach(() => {
-    // Reset mock before each test
-    getAllowedUrlCheckMock.mockReset();
-  });
+	beforeEach(() => {
+		// Reset mock before each test
+		getAllowedUrlCheckMock.mockReset();
+	});
 
-  it('renders loading state initially', () => {
-    // Setup mock to not resolve immediately
-    getAllowedUrlCheckMock.mockReturnValue(new Promise(() => {}));
-    
-    const { lastFrame } = render(
-      <PDPCheckUrlComponent 
-        options={{
-          user: 'john@example.com',
-          url: 'https://example.com/api',
-          method: 'GET',
-          tenant: 'default',
-        }} 
-      />
-    );
-    
-    expect(lastFrame()).toContain('Checking URL permission');
-  });
+	it('renders loading state initially', () => {
+		// Setup mock to not resolve immediately
+		getAllowedUrlCheckMock.mockReturnValue(new Promise(() => {}));
 
-  it('displays allowed result when permission is granted', async () => {
-    // Mock successful permission check
-    getAllowedUrlCheckMock.mockResolvedValue({ 
-      data: { allow: true },
-      error: null 
-    });
-    
-    const { lastFrame } = render(
-      <PDPCheckUrlComponent 
-        options={{
-          user: 'john@example.com',
-          url: 'https://example.com/api',
-          method: 'GET',
-          tenant: 'default',
-        }} 
-      />
-    );
-    
-    // Wait for the component to update
-    await vi.waitFor(() => {
-      expect(lastFrame()).toContain('Allowed');
-    });
-    
-    expect(lastFrame()).toContain('✓ Allowed');
-    expect(lastFrame()).toContain('URL: https://example.com/api');
-    expect(lastFrame()).toContain('User: john@example.com');
-  });
+		const { lastFrame } = render(
+			<PDPCheckUrlComponent
+				options={{
+					user: 'john@example.com',
+					url: 'https://example.com/api',
+					method: 'GET',
+					tenant: 'default',
+				}}
+			/>,
+		);
 
-  it('displays denied result when permission is not granted', async () => {
-    // Mock denied permission check
-    getAllowedUrlCheckMock.mockResolvedValue({ 
-      data: { allow: false },
-      error: null 
-    });
-    
-    const { lastFrame } = render(
-      <PDPCheckUrlComponent 
-        options={{
-          user: 'john@example.com',
-          url: 'https://example.com/private',
-          method: 'POST',
-          tenant: 'acme-corp',
-        }} 
-      />
-    );
-    
-    // Wait for the component to update
-    await vi.waitFor(() => {
-      expect(lastFrame()).toContain('Denied');
-    });
-    
-    expect(lastFrame()).toContain('✗ Denied');
-    expect(lastFrame()).toContain('URL: https://example.com/private');
-    expect(lastFrame()).toContain('Tenant: acme-corp');
-  });
+		expect(lastFrame()).toContain('Checking URL permission');
+	});
 
-  it('handles user attributes correctly', async () => {
-    // Mock successful permission check
-    getAllowedUrlCheckMock.mockResolvedValue({ 
-      data: { allow: true },
-      error: null 
-    });
-    
-    render(
-      <PDPCheckUrlComponent 
-        options={{
-          user: 'john@example.com',
-          url: 'https://example.com/api',
-          method: 'GET',
-          tenant: 'default',
-          userAttributes: ['role:admin', 'department:sales'],
-        }} 
-      />
-    );
-    
-    // Wait for the component to process
-    await vi.waitFor(() => {
-      expect(getAllowedUrlCheckMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          user: expect.objectContaining({
-            key: 'john@example.com',
-            attributes: expect.objectContaining({
-              role: 'admin',
-              department: 'sales',
-            }),
-          }),
-        }),
-        undefined
-      );
-    });
-  });
+	it('displays allowed result when permission is granted', async () => {
+		// Mock successful permission check
+		getAllowedUrlCheckMock.mockResolvedValue({
+			data: { allow: true },
+			error: null,
+		});
 
-  it('displays error message when API call fails', async () => {
-    // Mock API error
-    getAllowedUrlCheckMock.mockResolvedValue({ 
-      data: null,
-      error: 'Failed to connect to PDP' 
-    });
-    
-    const { lastFrame } = render(
-      <PDPCheckUrlComponent 
-        options={{
-          user: 'john@example.com',
-          url: 'https://example.com/api',
-          method: 'GET',
-          tenant: 'default',
-        }} 
-      />
-    );
-    
-    // Wait for the component to update
-    await vi.waitFor(() => {
-      expect(lastFrame()).toContain('Error');
-    });
-    
-    expect(lastFrame()).toContain('Error checking URL permission');
-    expect(lastFrame()).toContain('Failed to connect to PDP');
-  });
+		const { lastFrame } = render(
+			<PDPCheckUrlComponent
+				options={{
+					user: 'john@example.com',
+					url: 'https://example.com/api',
+					method: 'GET',
+					tenant: 'default',
+				}}
+			/>,
+		);
 
-  it('uses custom PDP URL when provided', async () => {
-    // Mock successful permission check
-    getAllowedUrlCheckMock.mockResolvedValue({ 
-      data: { allow: true },
-      error: null 
-    });
-    
-    const customPdpUrl = 'http://localhost:7766';
-    
-    render(
-      <PDPCheckUrlComponent 
-        options={{
-          user: 'john@example.com',
-          url: 'https://example.com/api',
-          method: 'GET',
-          tenant: 'default',
-          pdpurl: customPdpUrl,
-        }} 
-      />
-    );
-    
-    // Verify the custom PDP URL was passed to the hook
-    await vi.waitFor(() => {
-      expect(getAllowedUrlCheckMock).toHaveBeenCalledWith(
-        expect.any(Object),
-        customPdpUrl
-      );
-    });
-  });
+		// Wait for the component to update
+		await vi.waitFor(() => {
+			expect(lastFrame()).toContain('Allowed');
+		});
+
+		expect(lastFrame()).toContain('✓ Allowed');
+		expect(lastFrame()).toContain('URL: https://example.com/api');
+		expect(lastFrame()).toContain('User: john@example.com');
+	});
+
+	it('displays denied result when permission is not granted', async () => {
+		// Mock denied permission check
+		getAllowedUrlCheckMock.mockResolvedValue({
+			data: { allow: false },
+			error: null,
+		});
+
+		const { lastFrame } = render(
+			<PDPCheckUrlComponent
+				options={{
+					user: 'john@example.com',
+					url: 'https://example.com/private',
+					method: 'POST',
+					tenant: 'acme-corp',
+				}}
+			/>,
+		);
+
+		// Wait for the component to update
+		await vi.waitFor(() => {
+			expect(lastFrame()).toContain('Denied');
+		});
+
+		expect(lastFrame()).toContain('✗ Denied');
+		expect(lastFrame()).toContain('URL: https://example.com/private');
+		expect(lastFrame()).toContain('Tenant: acme-corp');
+	});
+
+	it('handles user attributes correctly', async () => {
+		// Mock successful permission check
+		getAllowedUrlCheckMock.mockResolvedValue({
+			data: { allow: true },
+			error: null,
+		});
+
+		render(
+			<PDPCheckUrlComponent
+				options={{
+					user: 'john@example.com',
+					url: 'https://example.com/api',
+					method: 'GET',
+					tenant: 'default',
+					userAttributes: ['role:admin', 'department:sales'],
+				}}
+			/>,
+		);
+
+		// Wait for the component to process
+		await vi.waitFor(() => {
+			expect(getAllowedUrlCheckMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					user: expect.objectContaining({
+						key: 'john@example.com',
+						attributes: expect.objectContaining({
+							role: 'admin',
+							department: 'sales',
+						}),
+					}),
+				}),
+				undefined,
+			);
+		});
+	});
+
+	it('displays error message when API call fails', async () => {
+		// Mock API error
+		getAllowedUrlCheckMock.mockResolvedValue({
+			data: null,
+			error: 'Failed to connect to PDP',
+		});
+
+		const { lastFrame } = render(
+			<PDPCheckUrlComponent
+				options={{
+					user: 'john@example.com',
+					url: 'https://example.com/api',
+					method: 'GET',
+					tenant: 'default',
+				}}
+			/>,
+		);
+
+		// Wait for the component to update
+		await vi.waitFor(() => {
+			expect(lastFrame()).toContain('Error');
+		});
+
+		expect(lastFrame()).toContain('Error checking URL permission');
+		expect(lastFrame()).toContain('Failed to connect to PDP');
+	});
+
+	it('uses custom PDP URL when provided', async () => {
+		// Mock successful permission check
+		getAllowedUrlCheckMock.mockResolvedValue({
+			data: { allow: true },
+			error: null,
+		});
+
+		const customPdpUrl = 'http://localhost:7766';
+
+		render(
+			<PDPCheckUrlComponent
+				options={{
+					user: 'john@example.com',
+					url: 'https://example.com/api',
+					method: 'GET',
+					tenant: 'default',
+					pdpurl: customPdpUrl,
+				}}
+			/>,
+		);
+
+		// Verify the custom PDP URL was passed to the hook
+		await vi.waitFor(() => {
+			expect(getAllowedUrlCheckMock).toHaveBeenCalledWith(
+				expect.any(Object),
+				customPdpUrl,
+			);
+		});
+	});
 });


### PR DESCRIPTION
The pr Implements a new CLI command that allows users to check permissions for a URL. This command interfaces with the Is Allowed Url API endpoint

pr handles this issues https://github.com/permitio/permit-cli/issues/80

closes #80