### PR TITLE
Fix audit logs: fix user display && correctly handle ReBAC resource instances in test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@permitio/cli",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@permitio/cli",
-			"version": "0.1.7",
+			"version": "0.1.8",
 			"license": "MIT",
 			"dependencies": {
 				"@scaleway/random-name": "^5.1.1",

--- a/source/components/test/auditTypes.ts
+++ b/source/components/test/auditTypes.ts
@@ -36,9 +36,39 @@ export interface AuditContext {
 	context?: Record<string, unknown>;
 }
 
+export interface DebugInformation {
+	rebac?: {
+		allow?: boolean;
+		allowing_roles?: Array<{
+			resource: string;
+			role: string;
+			reason: string;
+			sources: Array<{
+				type: string;
+				[key: string]: unknown;
+			}>;
+			[key: string]: unknown;
+		}>;
+		code?: string;
+		reason?: string;
+		[key: string]: unknown;
+	};
+	rbac?: Record<string, unknown>;
+	abac?: Record<string, unknown>;
+	request?: {
+		action?: string;
+		resource?: Record<string, unknown>;
+		tenant?: string;
+		user?: Record<string, unknown>;
+		[key: string]: unknown;
+	};
+	[key: string]: unknown;
+}
+
 export interface DetailedAuditLog extends AuditLog {
 	user_id: string;
 	context?: AuditContext;
+	debug?: DebugInformation;
 }
 
 /**
@@ -56,6 +86,7 @@ export interface AuditLogResponseData {
 	decision?: boolean;
 	pdp_config_id?: string;
 	context?: unknown;
+	debug?: unknown;
 	[key: string]: unknown;
 }
 

--- a/source/components/test/auditUtils.ts
+++ b/source/components/test/auditUtils.ts
@@ -114,14 +114,11 @@ export const createPdpRequest = (log: DetailedAuditLog): PdpRequestData => {
 			? context.resource.attributes || {}
 			: {};
 
-
 	let resourceKey = '';
 	let resourceId = '';
 
-	
 	const rebacAllowingRoles = log.debug?.rebac?.allowing_roles;
 
-	
 	if (rebacAllowingRoles && rebacAllowingRoles.length > 0) {
 		const rebacResource = rebacAllowingRoles[0]?.resource;
 		if (typeof rebacResource === 'string' && rebacResource.includes(':')) {
@@ -131,9 +128,7 @@ export const createPdpRequest = (log: DetailedAuditLog): PdpRequestData => {
 				resourceId = parts[1];
 			}
 		}
-	}
-	
-	else {
+	} else {
 		const isResourceInstance =
 			typeof log.resource === 'string' && log.resource.includes(':');
 

--- a/source/components/test/auditUtils.ts
+++ b/source/components/test/auditUtils.ts
@@ -149,7 +149,7 @@ export const createPdpRequest = (log: DetailedAuditLog): PdpRequestData => {
 		) {
 			resourceKey = context.resource.key.toString();
 		} else {
-			resourceKey = log.resource;
+			resourceKey = log.resource || '';
 		}
 
 		// Determine resource type with proper fallbacks

--- a/source/components/test/auditUtils.ts
+++ b/source/components/test/auditUtils.ts
@@ -148,6 +148,8 @@ export const createPdpRequest = (log: DetailedAuditLog): PdpRequestData => {
 			context.resource.key
 		) {
 			resourceKey = context.resource.key.toString();
+		} else {
+			resourceKey = log.resource;
 		}
 
 		// Determine resource type with proper fallbacks

--- a/source/components/test/auditUtils.ts
+++ b/source/components/test/auditUtils.ts
@@ -148,8 +148,6 @@ export const createPdpRequest = (log: DetailedAuditLog): PdpRequestData => {
 			context.resource.key
 		) {
 			resourceKey = context.resource.key.toString();
-		} else {
-			resourceKey = log.resource || '';
 		}
 
 		// Determine resource type with proper fallbacks

--- a/source/components/test/views/DifferenceResultView.tsx
+++ b/source/components/test/views/DifferenceResultView.tsx
@@ -10,7 +10,7 @@ const DifferenceResultView: React.FC<DifferenceResultViewProps> = ({
 	result,
 }) => (
 	<>
-		<Text>User: {result.auditLog.user_key || result.auditLog. user_id}</Text>
+		<Text>User: {result.auditLog.user_key || result.auditLog.user_id}</Text>
 		<Text>
 			Resource: {result.auditLog.resource} (type:{' '}
 			{result.auditLog.resource_type})

--- a/source/components/test/views/DifferenceResultView.tsx
+++ b/source/components/test/views/DifferenceResultView.tsx
@@ -10,7 +10,7 @@ const DifferenceResultView: React.FC<DifferenceResultViewProps> = ({
 	result,
 }) => (
 	<>
-		<Text>User: {result.auditLog.user_id}</Text>
+		<Text>User: {result.auditLog.user_key}</Text>
 		<Text>
 			Resource: {result.auditLog.resource} (type:{' '}
 			{result.auditLog.resource_type})

--- a/source/components/test/views/DifferenceResultView.tsx
+++ b/source/components/test/views/DifferenceResultView.tsx
@@ -10,7 +10,7 @@ const DifferenceResultView: React.FC<DifferenceResultViewProps> = ({
 	result,
 }) => (
 	<>
-		<Text>User: {result.auditLog.user_key}</Text>
+		<Text>User: {result.auditLog.user_key || result.auditLog. user_id}</Text>
 		<Text>
 			Resource: {result.auditLog.resource} (type:{' '}
 			{result.auditLog.resource_type})

--- a/source/components/test/views/ErrorResultView.tsx
+++ b/source/components/test/views/ErrorResultView.tsx
@@ -8,7 +8,7 @@ interface ErrorResultViewProps {
 
 const ErrorResultView: React.FC<ErrorResultViewProps> = ({ result }) => (
 	<>
-		<Text>User: {result.auditLog.user_key}</Text>
+		<Text>User: {result.auditLog.user_key || result.auditLog.user_id}</Text>
 		<Text>
 			Resource: {result.auditLog.resource} (type:{' '}
 			{result.auditLog.resource_type})

--- a/source/components/test/views/ErrorResultView.tsx
+++ b/source/components/test/views/ErrorResultView.tsx
@@ -8,7 +8,7 @@ interface ErrorResultViewProps {
 
 const ErrorResultView: React.FC<ErrorResultViewProps> = ({ result }) => (
 	<>
-		<Text>User: {result.auditLog.user_id}</Text>
+		<Text>User: {result.auditLog.user_key}</Text>
 		<Text>
 			Resource: {result.auditLog.resource} (type:{' '}
 			{result.auditLog.resource_type})


### PR DESCRIPTION
Fixes the user identification display in difference and error views to show `user_key` instead of `user_id`

And also fixes run audit command failing to properly compare ReBAC decisions

Changes:
- Added debug information to DetailedAuditLog interface
- Updated normalizeDetailedLog to preserve debug information from audit logs
- Enhanced createPdpRequest to extract resource instance IDs from ReBAC debug data
 
closes #103