### PR TITLE
add orm data filtering terraform file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage
 *.tf
 !templates/
 !templates/*.tf
+!source/templates/*.tf
 
 
 # .tfstate files

--- a/source/templates/orm-data-filtering.tf
+++ b/source/templates/orm-data-filtering.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_providers {
+    permitio = {
+      source = "permitio/permit-io"
+      version = "~> 0.0.12"
+    }
+  }
+}
+
+variable "PERMIT_API_KEY" {
+  type        = string
+  description = "The API key for the Permit.io API"
+}
+
+provider "permitio" {
+  api_url = "https://api.permit.io"
+  api_key = var.PERMIT_API_KEY
+}
+
+# Resources
+resource "permitio_resource" "project" {
+  name        = "Project"
+  description = ""
+  key         = "project"
+
+  actions = {
+    "read" = {
+      name = "read"
+    },
+    "create" = {
+      name = "create"
+    },
+    "update" = {
+      name = "update"
+    },
+    "delete" = {
+      name = "delete"
+    }
+  }
+  attributes = {
+  }
+}
+resource "permitio_resource" "task" {
+  name        = "Task"
+  description = ""
+  key         = "task"
+
+  actions = {
+    "read" = {
+      name = "read"
+    },
+    "create" = {
+      name = "create"
+    },
+    "update" = {
+      name = "update"
+    },
+    "delete" = {
+      name = "delete"
+    }
+  }
+  attributes = {
+  }
+}
+
+# Roles
+resource "permitio_role" "project__Member" {
+  key         = "Member"
+  name        = "Member"
+  resource    = permitio_resource.project.key
+  permissions = ["read"]
+
+  depends_on  = [permitio_resource.project]
+}
+resource "permitio_role" "task__Member" {
+  key         = "Member"
+  name        = "Member"
+  resource    = permitio_resource.task.key
+  permissions = ["read"]
+
+  depends_on  = [permitio_resource.task]
+}
+
+# Relations
+resource "permitio_relation" "project_task" {
+  key              = "parent"
+  name             = "parent"
+  subject_resource = permitio_resource.project.key
+  object_resource  = permitio_resource.task.key
+  depends_on = [
+    permitio_resource.task,
+    permitio_resource.project,
+  ]
+}
+
+# Role Derivations
+resource "permitio_role_derivation" "project_Member_to_task_Member" {
+  role        = permitio_role.project__Member.key
+  on_resource = permitio_resource.project.key
+  to_role     = permitio_role.task__Member.key
+  resource    = permitio_resource.task.key
+  linked_by   = permitio_relation.project_task.key
+  depends_on = [
+    permitio_role.project__Member,
+    permitio_resource.project,
+    permitio_role.task__Member,
+    permitio_resource.task,
+    permitio_relation.project_task
+  ]
+}

--- a/source/templates/orm-data-filtering.tf
+++ b/source/templates/orm-data-filtering.tf
@@ -2,19 +2,14 @@ terraform {
   required_providers {
     permitio = {
       source = "permitio/permit-io"
-      version = "~> 0.0.12"
+      version = "~> 0.0.14"
     }
   }
 }
 
-variable "PERMIT_API_KEY" {
-  type        = string
-  description = "The API key for the Permit.io API"
-}
-
 provider "permitio" {
   api_url = "https://api.permit.io"
-  api_key = var.PERMIT_API_KEY
+  api_key = {{API_KEY}}
 }
 
 # Resources


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a new Terraform policy template for the project-task-prisma model. It defines ReBAC-based roles, resources, and relationships for a Project and Task structure, enabling fine-grained access control with Prisma ORM. The template supports role derivation from projects to related tasks and is intended for use with the @permitio/permit-prisma extension.

## Type of Change

- [ ] Bug fix
- [ ] New feature/command
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/update
- [x] Other (please describe): Added exported .tf file

## Checklist

- [ ] I have created an issue and linked it in this PR
- [x] I have created a branch from `main` with an appropriate name (e.g., `fix/issue-123`, `feature/new-command`)
- [x] My code follows the project's coding style guidelines
- [ ] I have added tests for my changes (>90% coverage of new code)
- [ ] I have updated the documentation if necessary
- [x] All tests pass locally
- [x] Lint checks pass locally
- [x] I have reviewed my own code for potential issues

## New Command Details (if applicable)

- [ ] Command is placed in the `src/commands` directory
- [ ] Command file contains only argument configuration and a root command component
- [ ] Command is wrapped with the `AuthProvider` component
- [ ] Command has an optional `apiKey` argument
- [ ] API key scope is declared for the command
- [ ] Documentation added to the README

## Additional Notes

<!-- Any additional information that might be helpful for reviewers -->

## Screenshots/Recordings

<!-- Include a Loom recording demonstrating the command/feature/fix in action here. Recordings should include all edge cases required in the issue. -->
